### PR TITLE
Make image filenames relative to the label file

### DIFF
--- a/sloth/annotations/container.py
+++ b/sloth/annotations/container.py
@@ -204,7 +204,6 @@ class PickleContainer(AnnotationContainer):
         """
         Overwritten to write pickle files.
         """
-        # TODO make all image filenames relative to the label file
         f = open(fname, "wb")
         pickle.dump(annotations, f)
 
@@ -292,7 +291,6 @@ class OkapiAnnotationContainer(AnnotationContainer):
                         fileitem.frames().push_back(frameitem)
             container.files().push_back(fileitem)
 
-        # TODO make all image filenames relative to the label file
         container.WriteToFile(fname)
 
 
@@ -312,7 +310,6 @@ class JsonContainer(AnnotationContainer):
         """
         Overwritten to write JSON files.
         """
-        # TODO make all image filenames relative to the label file
         f = open(fname, "w")
         json.dump(annotations, f, indent=4, sort_keys=True)
 
@@ -333,7 +330,6 @@ class YamlContainer(AnnotationContainer):
         """
         Overwritten to write YAML files.
         """
-        # TODO make all image filenames relative to the label file
         f = open(fname, "w")
         yaml.dump(annotations, f)
 
@@ -398,8 +394,6 @@ class FeretContainer(AnnotationContainer):
         """
         Not implemented yet.
         """
-        # TODO make sure the image paths are
-        # relative to the label file's directory
         raise NotImplemented(
             "FeretContainer.serializeToFile() is not implemented yet."
         )

--- a/sloth/gui/labeltool.py
+++ b/sloth/gui/labeltool.py
@@ -384,6 +384,9 @@ class MainWindow(QMainWindow):
 
         fname = str(fname)
 
+        if os.path.isabs(fname):
+            fname = os.path.relpath(fname, str(path))
+
         for pattern in image_types:
             if fnmatch.fnmatch(fname, pattern):
                 return self.labeltool.addImageFile(fname)


### PR DESCRIPTION
The image filenames written to the label files were absolute pathnames.
Change this to use filenames relative to the label file.
