### PR TITLE
Avoid trailing whitespace in the JSON output

### DIFF
--- a/sloth/annotations/container.py
+++ b/sloth/annotations/container.py
@@ -314,7 +314,7 @@ class JsonContainer(AnnotationContainer):
         """
         # TODO make all image filenames relative to the label file
         f = open(fname, "w")
-        json.dump(annotations, f, indent=4, sort_keys=True)
+        json.dump(annotations, f, indent=4, separators=(',', ': '), sort_keys=True)
 
 
 class YamlContainer(AnnotationContainer):


### PR DESCRIPTION
The default separators used in the Python JSON library's dump() write
output with trailing whitespace. Use custom separators to avoid that, as
described in the documentation:

  http://docs.python.org/2/library/json.html
