### PR TITLE
Append only new files

### DIFF
--- a/sloth/core/commands.py
+++ b/sloth/core/commands.py
@@ -123,6 +123,7 @@ class AppendFilesCommand(BaseCommand):
             else:
                 logger.debug("Adding image file: %s" % rel_filename)
                 item = self.labeltool.addImageFile(rel_filename)
+            present_filenames.add(rel_filename)
 
             if options['unlabeled']:
                 item.setUnlabeled(True)


### PR DESCRIPTION
When appending files, check if that file is already in the label file.
Do not append it if it's already there.
