### PR TITLE
Add a newline at the end of the JSON file

### DIFF
--- a/sloth/annotations/container.py
+++ b/sloth/annotations/container.py
@@ -313,6 +313,7 @@ class JsonContainer(AnnotationContainer):
         """
         f = open(fname, "w")
         json.dump(annotations, f, indent=4, separators=(',', ': '), sort_keys=True)
+        f.write("\n")
 
 
 class MsgpackContainer(AnnotationContainer):


### PR DESCRIPTION
Editors like Vim add a newline at the end of the file when saving. git
then complains loudly about the "change":

  -]
  \ No newline at end of file
  +]

Add a newline to the JSON file to be compatible with editors.
