### PR TITLE
fix crash on first launch

### DIFF
--- a/sloth/gui/labeltool.py
+++ b/sloth/gui/labeltool.py
@@ -305,7 +305,8 @@ class MainWindow(QMainWindow):
         if isinstance(locked, QVariant): locked = locked.toBool()
         self.resize(size)
         self.move(pos)
-        self.restoreState(state)
+        if state is not None:
+                self.restoreState(state)
         self.ui.actionLocked.setChecked(bool(locked))
 
     def saveApplicationSettings(self):


### PR DESCRIPTION
When there is no previous state you get a segmentation fault. This fixes it. 

Experienced by me and also kaggle user [Jeffrey Richley](https://www.kaggle.com/c/noaa-right-whale-recognition/forums/t/16328/python-alternative-to-labelling-tool/92693#post92693). Fault trace:

```
Traceback (most recent call last):
  File "./bin/sloth", line 16, in <module>
    labeltool.execute_from_commandline(sys.argv)
  File "C:\personal\kaggle\sloth\sloth\core\labeltool.py", line 152, in execute_from_commandline
    self._mainwindow = MainWindow(self)
  File "C:\personal\kaggle\sloth\sloth\gui\labeltool.py", line 74, in __init__
    self.loadApplicationSettings()
  File "C:\personal\kaggle\sloth\sloth\gui\labeltool.py", line 308, in loadApplicationSettings
    self.restoreState(state)
TypeError: QMainWindow.restoreState(QByteArray, int version=0): argument 1 has unexpected type 'NoneType'
```