### PR TITLE
Polygonshape

### DIFF
--- a/sloth/gui/annotationscene.py
+++ b/sloth/gui/annotationscene.py
@@ -410,7 +410,7 @@ class AnnotationScene(QGraphicsScene):
 
             self._message_text_item.paint(painter, QStyleOptionGraphicsItem(), None)
 
-    # 
+    #
     # utility functions
     #
 

--- a/sloth/gui/annotationscene.py
+++ b/sloth/gui/annotationscene.py
@@ -411,7 +411,6 @@ class AnnotationScene(QGraphicsScene):
             self._message_text_item.paint(painter, QStyleOptionGraphicsItem(), None)
 
     #
-    #
     # utility functions
     #
 

--- a/sloth/gui/annotationscene.py
+++ b/sloth/gui/annotationscene.py
@@ -411,6 +411,7 @@ class AnnotationScene(QGraphicsScene):
             self._message_text_item.paint(painter, QStyleOptionGraphicsItem(), None)
 
     #
+    #
     # utility functions
     #
 

--- a/sloth/items/items.py
+++ b/sloth/items/items.py
@@ -769,6 +769,7 @@ class PolygonItem(BaseItem):
         self._polygon = None
 
         self._updatePolygon(self._dataToPolygon(self._model_item))
+
         LOG.debug("Constructed polygon %s for model item %s" %
                   (self._polygon, model_item))
 
@@ -830,3 +831,10 @@ class PolygonItem(BaseItem):
     def dataChange(self):
         polygon = self._dataToPolygon(self._model_item)
         self._updatePolygon(polygon)
+
+    def shape(self):
+        shape = QPainterPath()
+        for pt in self._polygon:
+            shape.lineTo(pt)
+        shape.lineTo(self._polygon[0])
+        return shape


### PR DESCRIPTION
When using many polygons, specially non-convex and tightly packed polygons, the selection mechanism essentially becomes useless - it might as well select polygons at random, and I often find myself cycling through all polygons with tab to get the one I want. It seems this is because the selection mechanism uses the bounding box, which tend to overlap greatly in this situation. Overriding the `shape()` method of polygon seems to greatly improve the accuracy of selection. However, I should note that I have no knowledge of Qt, so there might be a better way. My googling didn't find anything else obviously better.

One issue that still needs to be addressed is that it becomes impossible to select polygons buried under another one. This was still often the case before this modification. I'm thinking that clicking with a modifier key like shift could cycle between the polygons under the cursor, similar to how Inkscape does it. I could have a look at implementing this if there's interest.