### PR TITLE
Add 'extreme clicking' bounding box annotations

### DIFF
--- a/sloth/conf/default_config.py
+++ b/sloth/conf/default_config.py
@@ -1,7 +1,7 @@
 # This is sloth's default configuration.
 #
 # The configuration file is a simple python module with module-level
-# variables.  This module contains the default values for sloth's 
+# variables.  This module contains the default values for sloth's
 # configuration variables.
 #
 # In all cases in the configuration where a python callable (such as a
@@ -16,16 +16,16 @@
 # be one dictionary that contains the following keys:
 #
 #   - 'item' : Visualization item for this label. This can be
-#              any python callable or a module path string 
+#              any python callable or a module path string
 #              implementing the visualization item interface.
 #
 #   - 'inserter' : (optional) Item inserter for this label.
 #                  If the user selects to insert a new label of this class
-#                  the inserter is responsible to actually 
+#                  the inserter is responsible to actually
 #                  capture the users mouse actions and insert
 #                  a new label into the annotation model.
 #
-#   - 'hotkey' : (optional) A keyboard shortcut starting 
+#   - 'hotkey' : (optional) A keyboard shortcut starting
 #                the insertion of a new label of this class.
 #
 #   - 'attributes' : (optional) A dictionary that defines the
@@ -54,6 +54,15 @@ LABELS = (
     },
     {
         'attributes': {
+            'class':      'extreme_clicks',
+        },
+        'inserter': 'sloth.items.ExtremeClickingInserter',
+        'item':     'sloth.items.ExtremeClickingItem',
+        'hotkey':   'e',
+        'text':     'Extreme Clicks',
+    },
+    {
+        'attributes': {
             'class':    'point',
         },
         'inserter': 'sloth.items.PointItemInserter',
@@ -78,7 +87,7 @@ LABELS = (
 # with at least 2 entries, where the first entry is the hotkey (sequence),
 # and the second entry is the function that is called.  The function
 # should expect a single parameter, the labeltool object.  The optional
-# third entry -- if present -- is expected to be a string describing the 
+# third entry -- if present -- is expected to be a string describing the
 # action.
 HOTKEYS = (
     ('Space',     [lambda lt: lt.currentImage().confirmAll(),
@@ -115,9 +124,7 @@ CONTAINERS = (
 # PLUGINS
 #
 # A list/tuple of classes implementing the sloth plugin interface.  The
-# classes can either be given directly or their module path be specified 
+# classes can either be given directly or their module path be specified
 # as string.
 PLUGINS = (
 )
-
-

--- a/sloth/items/inserters.py
+++ b/sloth/items/inserters.py
@@ -99,23 +99,32 @@ class ExtremeClickingInserter(ItemInserter):
         self._points.addToGroup(new_point)
 
         if len(self._points.childItems()) == 4:
-            x1 = sys.maxint
-            x2 = -sys.maxint
-            y1 = sys.maxint
-            y2 = -sys.maxint
+            left = QPointF(sys.maxint, 0)
+            right = QPointF(-sys.maxint, 0)
+            top = QPointF(0, sys.maxint)
+            bottom = QPointF(0, -sys.maxint)
             for point in self._points.childItems():
-                x1 = min(x1, point.rect().x())
-                x2 = max(x2, point.rect().x())
-                y1 = min(y1, point.rect().y())
-                y2 = max(y2, point.rect().y())
-            width = x2 - x1
-            height = y2 - y1
+                if point.rect().x() < left.x():
+                    left = point.rect()
+                if point.rect().y() < top.y():
+                    top = point.rect()
+                if (point.rect().x() + point.rect().width()) > right.x():
+                    right = point.rect()
+                if (point.rect().y() + point.rect().height()) > bottom.y():
+                    bottom = point.rect()
+
+            width = right.x() - left.x()
+            height = bottom.y() - top.y()
 
             if width > 1 and height > 1:
-                self._ann.update({self._prefix + 'x': x1,
-                                  self._prefix + 'y': y1,
-                                  self._prefix + 'width': width,
-                                  self._prefix + 'height': height})
+                self._ann.update({self._prefix + 'left_x': left.x(),
+                                  self._prefix + 'left_y': left.y(),
+                                  self._prefix + 'right_x': right.x(),
+                                  self._prefix + 'right_y': right.y(),
+                                  self._prefix + 'top_x': top.x(),
+                                  self._prefix + 'top_y': top.y(),
+                                  self._prefix + 'bottom_x': bottom.x(),
+                                  self._prefix + 'bottom_y': bottom.y()})
                 self._ann.update(self._default_properties)
                 if self._commit:
                     image_item.addAnnotation(self._ann)


### PR DESCRIPTION
This PR implements the annotation format introduced in https://arxiv.org/abs/1708.02750v1.

Users are asked to annotate the 4 extremal points (left, right, top, and bottom-most) of an object. The authors of the paper claim, that this is a more natural way of defining bounding-boxes of objects.

Implementation remarks:
  - the clicking order does not matter
  - it's not possible to move the whole box. Instead one can drag the single points with right button move.