### PR TITLE
Closed in favor of #156

### DIFF
--- a/sloth/gui/annotationscene.py
+++ b/sloth/gui/annotationscene.py
@@ -20,6 +20,7 @@ class AnnotationScene(QGraphicsScene):
         self._scene_item = None
         self._message = ""
         self._labeltool = labeltool
+        self._switch_image_mode = False
 
         self._itemfactory = Factory(items)
         self._inserterfactory = Factory(inserters)
@@ -146,7 +147,8 @@ class AnnotationScene(QGraphicsScene):
         if inserter is None:
             raise InvalidArgumentException("Could not find inserter for class '%s' with default properties '%s'" % (label_class, default_properties))
         inserter.inserterFinished.connect(self.onInserterFinished)
-        inserter.annotationFinished.connect(self.onAnnotationFinished)
+        if self._switch_image_mode:
+            inserter.annotationFinished.connect(self.onAnnotationFinished)
         self._labeltool.currentImageChanged.connect(inserter.imageChange)
         self._inserter = inserter
         LOG.debug("Created inserter for class '%s' with default properties '%s'" % (label_class, default_properties))
@@ -497,4 +499,13 @@ class AnnotationScene(QGraphicsScene):
 
         functools.update_wrapper(paint, oldpaint)
         RectItem.paint = paint
+
+    # Switch image after annotation mode change
+    def switchImageMode(self, enabled):
+        self._switch_image_mode = enabled
+        if self._inserter is not None:
+            if enabled:
+                self._inserter.annotationFinished.connect(self.onAnnotationFinished)
+            else:
+                self._inserter.annotationFinished.disconnect(self.onAnnotationFinished)
 

--- a/sloth/gui/annotationscene.py
+++ b/sloth/gui/annotationscene.py
@@ -128,6 +128,11 @@ class AnnotationScene(QGraphicsScene):
         self._labeltool.exitInsertMode()
         self._inserter = None
 
+    def onAnnotationFinished(self):
+        self._labeltool.currentImage().confirmAll()
+        self._labeltool.currentImage().setUnlabeled(False)
+        self._labeltool.gotoNext()
+
     def onInsertionModeStarted(self, label_class):
         # Abort current inserter
         if self._inserter is not None:
@@ -141,6 +146,7 @@ class AnnotationScene(QGraphicsScene):
         if inserter is None:
             raise InvalidArgumentException("Could not find inserter for class '%s' with default properties '%s'" % (label_class, default_properties))
         inserter.inserterFinished.connect(self.onInserterFinished)
+        inserter.annotationFinished.connect(self.onAnnotationFinished)
         self._labeltool.currentImageChanged.connect(inserter.imageChange)
         self._inserter = inserter
         LOG.debug("Created inserter for class '%s' with default properties '%s'" % (label_class, default_properties))

--- a/sloth/gui/labeltool.py
+++ b/sloth/gui/labeltool.py
@@ -168,6 +168,10 @@ class MainWindow(QMainWindow):
             self.interpolateRange.interpolateRange()
             self.annotationMenu["Interpolate range"].setChecked(False)
 
+    def onSwitchImageModeChanged(self):
+        checked = self.annotationMenu["Switch image after annotation"].isChecked()
+        self.scene.switchImageMode(checked)
+
     def onScaleChanged(self, scale):
         self.zoominfo.setText("%.2f%%" % (100 * scale, ))
 
@@ -217,6 +221,12 @@ class MainWindow(QMainWindow):
             self.annotationMenu[a] = action
 
         for a in ["Interpolate range"]:
+            action = QAction(a, self)
+            action.setCheckable(True)
+            self.ui.menuAnnotation.addAction(action)
+            self.annotationMenu[a] = action
+
+        for a in ["Switch image after annotation"]:
             action = QAction(a, self)
             action.setCheckable(True)
             self.ui.menuAnnotation.addAction(action)
@@ -343,6 +353,7 @@ class MainWindow(QMainWindow):
         ## annotation menu
         self.annotationMenu["Copy from previous"].changed.connect(self.onCopyAnnotationsModeChanged)
         self.annotationMenu["Interpolate range"].changed.connect(self.onInterpolateRangeModeChanged)
+        self.annotationMenu["Switch image after annotation"].changed.connect(self.onSwitchImageModeChanged)
 
     def loadApplicationSettings(self):
         settings = QSettings()


### PR DESCRIPTION
Our data labelers are tired of pressing Space after setting point on image every time. This pull request adds option in annotation menu that enables automatic image switch (in fact, same actions that Space key do) after annotationFinished signal.