### PR TITLE
Ask for file overwrite

### DIFF
--- a/sloth/gui/labeltool.py
+++ b/sloth/gui/labeltool.py
@@ -407,7 +407,13 @@ class MainWindow(QMainWindow):
         filename = self.labeltool.getCurrentFilename()
         if filename is None:
             return self.fileSaveAs()
-        return self.labeltool.saveAnnotations(filename)
+        else:
+            reply = QMessageBox.question(self,
+                    "%s - Overwrite file" % (APP_NAME),
+                    "Are you sure to overwrite %s?" % (filename),
+                    QMessageBox.Yes|QMessageBox.No|QMessageBox.Cancel)
+            if reply == QMessageBox.Yes:
+                return self.labeltool.saveAnnotations(filename)
 
     def fileSaveAs(self):
         fname = '.'  # self.annotations.filename() or '.'


### PR DESCRIPTION
Our data labelers fucked up some batches because they haven't started new instance of sloth before starting new batch. New dialog window is added to double-check that they want to overwrite their work.