### PR TITLE
Support for adding multiple actions for a single plug-in

### DIFF
--- a/sloth/core/labeltool.py
+++ b/sloth/core/labeltool.py
@@ -215,7 +215,11 @@ class LabelTool(QObject):
             p = plugin(self)
             self._plugins.append(p)
             action = p.action()
-            self.pluginLoaded.emit(action)
+            if isinstance(action, (list, tuple)):
+                for a in action:
+                    self.pluginLoaded.emit(a)
+            else:
+                self.pluginLoaded.emit(action)
 
     ###
     ### Annoation file handling


### PR DESCRIPTION
I have a plug in, which I sometimes want to run on a current image only, and sometimes on the whole set. This requires two menu items, to make things easy.
This change allows plugin.action() method to return a list or a tuple of actions/menu items to be added to the plugin menu, or  a single item (scalar).