### PR TITLE
Add feature: display image index at status bar.

### DIFF
--- a/sloth/gui/labeltool.py
+++ b/sloth/gui/labeltool.py
@@ -138,6 +138,10 @@ class MainWindow(QMainWindow):
         w = img.shape[1]
         self.image_resolution.setText("%dx%d" % (w, h))
 
+        image_index =  new_image.index().row() + 1
+        num_image = self.labeltool.model().root().numFiles()
+        self.image_index.setText("%d/%d" % (image_index, num_image))
+
         # TODO: This info should be obtained from AnnotationModel or LabelTool
         if isinstance(new_image, FrameModelItem):
             self.controls.setFrameNumAndTimestamp(new_image.framenum(), new_image.timestamp())
@@ -275,6 +279,10 @@ class MainWindow(QMainWindow):
 
         self.scene.selectionChanged.connect(self.scene.onSelectionChanged)
         self.treeview.selectedItemsChanged.connect(self.scene.onSelectionChangedInTreeView)
+
+        self.image_index = QLabel("0/0")
+        self.image_index.setFrameStyle(QFrame.StyledPanel)
+        self.statusBar().addPermanentWidget(self.image_index)
 
         self.posinfo = QLabel("-1, -1")
         self.posinfo.setFrameStyle(QFrame.StyledPanel)


### PR DESCRIPTION
Add a new feature: display image index at status bar. Sometimes I have to label more than 5,000 images, thus I would like to know up to which image I have labelled. There are so many images and some images share the same name. Therefore, it is very difficult to even impossible to scroll the image list to find my last labelled image just by name.

However, if I know the index of the image which I labelled last time, I would be able to locate it quickly and continue labelling remaining images. See below for example:

![image-index](https://user-images.githubusercontent.com/16900620/38788359-e0a01d98-40f8-11e8-9fe8-2b96901c50bb.png)

